### PR TITLE
Fixes non-ASCII characters being mangled in Enyo 1 apps.

### DIFF
--- a/framework/build/enyo-build.js
+++ b/framework/build/enyo-build.js
@@ -5,7 +5,7 @@
 enyo.sheet = function(a) {
 document.write('<link href="' + a + '" media="screen" rel="stylesheet" type="text/css" />');
 }, enyo.script = function(a) {
-document.write('<script src="' + a + '" type="text/javascript" onerror="console.error(\'Error loading script ' + a + "')\"></script>");
+document.write('<script src="' + a + '" type="text/javascript" charset="utf-8" onerror="console.error(\'Error loading script ' + a + "')\"></script>");
 }, enyo.path = {
 pattern: /\$([^\/\\]*)(\/)?/g,
 rewrite: function(a) {

--- a/framework/source/dependency-loader.js
+++ b/framework/source/dependency-loader.js
@@ -4,7 +4,7 @@
 	};
 
 	enyo.script = function(s) {
-		document.write('<script src="' + s + '" type="text/javascript" onerror="console.error(\'Error loading script ' + s + '\')"></script>');
+		document.write('<script src="' + s + '" type="text/javascript" charset="utf-8" onerror="console.error(\'Error loading script ' + s + '\')"></script>');
 	}
 
 	enyo.path = {


### PR DESCRIPTION
This updates Enyo 1 to load JavaScript as UTF-8, as does Enyo 2. (Enyo 2 apps were not affected.)  This issue did not manifest under webOS 2.2 nor 3.0, as JavaScript was loaded using the UTF-8 encoding by default.  The standards do not appear to specify a default charset for JavaScript loaded using the file: protocol, so this does not appear to be the HTML renderer's responsibility, but rather, the framework's.

I'm not aware of any of the built-in apps nor apps available through Preware 2 using non-ASCII characters.  I  observed this in my app Zap Photoshare, of which I can supply a copy to anyone.  I believe Garfonso and Herrie have observed this.
