### PR TITLE
Remove "HP Find More" accounts option

### DIFF
--- a/framework/lib/accounts/source/add-account.js
+++ b/framework/lib/accounts/source/add-account.js
@@ -64,13 +64,14 @@ enyo.kind({
 		if (!this.templates || inIndex > this.templates.length)
 			return false;
 		// The last item in the list is "Find More ..."
+		// Disable the HP Find More bits ;)
 		if (inIndex == this.templates.length) {
 			// Don't add "Find more" for the Phone app
-			if (this.capability === "PHONE")
-				return false;
-			this.$.templateIcon.setSrc(AccountsUtil.libPath + "images/appcatalog-32x32.png");
-			this.$.templateName.setContent(AccountsUtil.TEXT_FIND_MORE);
-			return true;
+			//if (this.capability === "PHONE")
+			return false;
+			//this.$.templateIcon.setSrc(AccountsUtil.libPath + "images/appcatalog-32x32.png");
+			//this.$.templateName.setContent(AccountsUtil.TEXT_FIND_MORE);
+			//return true;
 		}
 		if (this.templates[inIndex].icon)
 			this.$.templateIcon.setSrc(this.templates[inIndex].icon.loc_32x32);

--- a/framework/lib/accounts/source/entry-first-launch.js
+++ b/framework/lib/accounts/source/entry-first-launch.js
@@ -244,13 +244,14 @@ enyo.kind({
 		if (!this.addTemplates || inIndex > this.addTemplates.length)
 			return false;
 		// The last item in the list is "Find More ..."
+		//Disable the "HP Find More" option
 		if (inIndex == this.addTemplates.length) {
 			// Don't add "Find more" for the Phone app
-			if (this.capability === "PHONE")
+			//if (this.capability === "PHONE")
 				return false;
-			this.$.templateIcon.setSrc(AccountsUtil.libPath + "images/appcatalog-32x32.png");
-			this.$.templateName.setContent(AccountsUtil.TEXT_FIND_MORE);
-			return true;
+			//this.$.templateIcon.setSrc(AccountsUtil.libPath + "images/appcatalog-32x32.png");
+			//this.$.templateName.setContent(AccountsUtil.TEXT_FIND_MORE);
+			//return true;
 		}
 		if (this.addTemplates[inIndex].icon)
 			this.$.templateIcon.setSrc(this.addTemplates[inIndex].icon.loc_32x32);


### PR DESCRIPTION
Since we shouldn't expect any more accounts from HP, no need to add this option anymore.