### PR TITLE
Enyo-1.0: Make -webkit-border-image work with Chromium 51 and higher

### DIFF
--- a/framework/build/enyo-build.css
+++ b/framework/build/enyo-build.css
@@ -1,4 +1,7 @@
 /* Enyo v1.0 | Copyright 2011-2012 Hewlett-Packard Development Company, L.P. | enyojs.com | enyojs.com/license */
+/* Updated for upgrade to QT 5.8 with Chromium 53 based rendering engine */
+/* We need to explicitly define 'border-style: solid' since Chromium 51 in order for the border-image to keep working correctly and to be compliant with standard */
+/* See https://www.w3.org/TR/2005/WD-css3-background-20050216/#the-border-image and https://groups.google.com/a/chromium.org/forum/#!searchin/blink-dev/border-image/blink-dev/J7rvFkcn8TU/OtIcXTDDAQAJ */
 /* dom/dom.css */
 
 /*
@@ -409,6 +412,7 @@ html, body, input, button {
 	min-width: 14px;
 	min-height: 20px;
 	-webkit-border-image: url(palm/themes/Onyx/images/button-up.png) 4 4 4 4 stretch stretch;
+	border-style: solid;
 	border-width: 4px;
 	border-radius: 5px;
 	margin: 3px;
@@ -418,15 +422,18 @@ html, body, input, button {
 
 .enyo-button.enyo-button-down, .enyo-button.enyo-button-depressed {
 	-webkit-border-image: url(palm/themes/Onyx/images/button-down.png) 4 4 4 4 stretch stretch;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-button {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/button-up.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-button.enyo-button-down, .enyo-button.enyo-button-depressed {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/button-down.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -569,38 +576,46 @@ html, body, input, button {
 @media (-webkit-max-device-pixel-ratio:1.49) { /* 1x */
 	.enyo-radiobutton.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 0 16 556 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 37 16 519 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 74 16 482 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 111 16 445 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 148 16 408 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 185 16 371 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 222 16 334 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 259 16 297 16;
+		border-style: solid;
 	}
 
 
@@ -608,38 +623,46 @@ html, body, input, button {
 
 	.enyo-radiobutton-dark.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 296 16 260 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 333 16 223 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 370 16 186 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 407 16 149 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 444 16 112 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 481 16 75 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 518 16 38 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 555 16 1 16;
+		border-style: solid;
 	}
 
 
@@ -647,6 +670,7 @@ html, body, input, button {
 
 	.enyo-tabbutton.enyo-first, .enyo-tabbutton.enyo-middle, .enyo-tabbutton.enyo-last, .enyo-tabbutton.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 74 16 482 16;
+		border-style: solid;
 	}
 
 	.enyo-tabbutton.enyo-first.enyo-button-depressed,
@@ -658,6 +682,7 @@ html, body, input, button {
 	.enyo-tabbutton.enyo-single.enyo-button-depressed,
 	.enyo-tabbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 111 16 445 16;
+		border-style: solid;
 	}
 
 }
@@ -673,38 +698,46 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-radiobutton.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 0 16 834 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 55 16 779 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 110 16 724 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 165 16 669 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 220 16 614 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 275 16 559 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 330 16 504 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 385 16 449 16;
+		border-style: solid;
 	}
 
 
@@ -712,38 +745,46 @@ html, body, input, button {
 
 	.enyo-radiobutton-dark.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 440 16 394 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 495 16 339 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 550 16 284 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 605 16 229 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 660 16 174 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 715 16 119 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 770 16 64 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 825 16 9 16;
+		border-style: solid;
 	}
 
 
@@ -751,6 +792,7 @@ html, body, input, button {
 
 	.enyo-tabbutton.enyo-first, .enyo-tabbutton.enyo-middle, .enyo-tabbutton.enyo-last, .enyo-tabbutton.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 110 16 724 16;
+		border-style: solid;
 	}
 
 	.enyo-tabbutton.enyo-first.enyo-button-depressed,
@@ -762,6 +804,7 @@ html, body, input, button {
 	.enyo-tabbutton.enyo-single.enyo-button-depressed,
 	.enyo-tabbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 165 16 669 16;
+		border-style: solid;
 	}
 }
 
@@ -800,62 +843,75 @@ html, body, input, button {
 
 	.enyo-grouped-toolbutton.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 0 16 556 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 37 16 519 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 74 16 482 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 111 16 445 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 148 16 408 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 185 16 371 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 222 16 334 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 259 16 297 16;
+		border-style: solid;
 	}
 
 	/* dark */
 
 	.enyo-grouped-toolbutton-dark.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 296 16 260 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 333 16 223 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 370 16 186 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 407 16 149 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 444 16 112 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-depressed,
@@ -865,11 +921,13 @@ html, body, input, button {
 
 	.enyo-grouped-toolbutton-dark.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 518 16 38 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images/radiobutton.png) 555 16 1 16;
+		border-style: solid;
 	}
 }
 
@@ -877,76 +935,92 @@ html, body, input, button {
 
 	.enyo-grouped-toolbutton.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 0 16 834 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 55 16 779 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 110 16 724 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 165 16 669 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 220 16 614 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 275 16 559 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 330 16 504 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 385 16 449 16;
+		border-style: solid;
 	}
 
 	/* dark */
 
 	.enyo-grouped-toolbutton-dark.enyo-first {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 440 16 394 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 495 16 339 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 550 16 284 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 605 16 229 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 660 16 174 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 715 16 119 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 770 16 64 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/radiobutton.png) 825 16 9 16;
+		border-style: solid;
 	}
 }
 
@@ -1013,11 +1087,13 @@ html, body, input, button {
 	padding: 4px 8px;
 	border-style: none;
 	-webkit-border-image: url(palm/themes/Onyx/images/button-toolbar.png) 4 4 4 4 stretch stretch;
+	border-style: solid;
 }
 
 
 .enyo-tool-button-client.enyo-tool-button-captioned.enyo-button-down, .enyo-tool-button-client.enyo-button-depressed {
 	-webkit-border-image: url(palm/themes/Onyx/images/button-down.png) 4 4 4 4 stretch stretch;
+	border-style: solid;
 }
 
 .enyo-tool-button-client.enyo-button-depressed {
@@ -1033,10 +1109,12 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-tool-button-client.enyo-tool-button-captioned.enyo-button-down, .enyo-tool-button-client.enyo-button-depressed {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/button-down.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-tool-button-client.enyo-tool-button-captioned {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/button-toolbar.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -1079,11 +1157,13 @@ html, body, input, button {
 	-webkit-box-sizing: border-box;
 	border-width: 24px;
 	-webkit-border-image: url(palm/themes/Onyx/images/popup.png) 24 24 24 24 stretch stretch;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-popup {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/popup.png) 36 36 36 36 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -1101,6 +1181,7 @@ html, body, input, button {
 	min-width: inherit;
 	border-width: 20px;
 	-webkit-border-image: url(palm/themes/Onyx/images/menu-background.png) 20 20 20 20 stretch stretch;
+	border-style: solid;
 	
 	/* FIXME: consider when works more reliably */
 	/*
@@ -1159,6 +1240,7 @@ html, body, input, button {
 	}
 	.enyo-popup.enyo-popup-menu {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/menu-background.png) 30 30 30 30 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -1290,6 +1372,7 @@ html, body, input, button {
 	font-size: 18px;
 	border-width: 12px 24px 20px 24px;
 	-webkit-border-image: url(palm/themes/Onyx/images/appmenu.png) 12 24 20 24 stretch stretch;
+	border-style: solid;
 	color: white;
 	top: 0px;
 	left: -10px;
@@ -1318,6 +1401,7 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-popup.enyo-appmenu {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/appmenu.png) 18 36 30 36 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -1325,6 +1409,7 @@ html, body, input, button {
 
 .enyo-appmenu-item.enyo-item {
 	-webkit-border-image: url(palm/themes/Onyx/images/appmenu-divider.png) 0 0 2 0 stretch;
+	border-style: solid;
 	color: white;
 	border-bottom: 2px;
 	padding: 10px 7px 10px 5px;
@@ -1344,6 +1429,7 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-appmenu-item.enyo-item { 
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/appmenu-divider.png) 0 0 3 0 stretch;
+		border-style: solid;
 	}
 	
 	.enyo-appmenu-item.enyo-held {
@@ -1469,6 +1555,7 @@ html, body, input, button {
 .enyo-progress-bar {
 	height: 12px;
 	border-width: 0 4px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/progress-bar.png) 0 4 0 4 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -1478,6 +1565,7 @@ html, body, input, button {
 	margin: 0 -5px;
 	height: 12px;
 	border-width: 0 4px;
+	border-style: solid;
 	position: absolute;
 	z-index:10; /* for progressSlider altBarPosition */
 	-webkit-border-image: url(palm/themes/Onyx/images/progress-bar-inner.png) 0 4 0 4 repeat repeat;
@@ -1487,9 +1575,11 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-bar {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/progress-bar.png) 0 6 0 6 stretch stretch;
+		border-style: solid;
 	}
 	.enyo-progress-bar-inner {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/progress-bar-inner.png) 0 6 0 6 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -1501,6 +1591,7 @@ html, body, input, button {
 .enyo-progress-bar-item {
 	min-height: 24px;
 	border-width: 12px 0px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/progress-item.png) 12 0 12 0 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -1511,6 +1602,7 @@ html, body, input, button {
 	padding: 12px 0px;
 	height:100%;
 	border-width: 0 8px 0 0;
+	border-style: solid;
 	position:absolute;
 	-webkit-border-image: url(palm/themes/Onyx/images/progress-item-inner.png) 0 8 0 0 repeat stretch;
 }
@@ -1523,9 +1615,11 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-bar-item {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/progress-item.png) 18 0 18 0 stretch repeat;
+		border-style: solid;
 	}
 	.enyo-progress-bar-item-inner {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/progress-item-inner.png) 0 12 0 0 repeat stretch;
+		border-style: solid;
 	}	
 }
 
@@ -1536,6 +1630,7 @@ html, body, input, button {
 	min-height: 34px;
 	border-width: 4px;
 	border-radius: 5px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/button-down.png) 4 4 4 4 stretch stretch;
 	color: white;
 	background-color: rgba(23,23,23,0.5);
@@ -1551,6 +1646,7 @@ html, body, input, button {
 	bottom: 0;
 	border-width: 4px;
 	border-radius: 5px;
+	border-style: solid;
 	position: absolute;
 	-webkit-border-image: url(palm/themes/Onyx/images/button.png) 4 4 4 4 stretch stretch;
 }
@@ -1572,10 +1668,12 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-button {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/button-down.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-button-inner {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/button.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-button-cancel {
@@ -1622,6 +1720,7 @@ html, body, input, button {
 .enyo-progress-slider {
 	height: 10px;
 	border-width: 0 4px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/slider-track.png) 0 4 0 4 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -1630,6 +1729,7 @@ html, body, input, button {
 .enyo-progress-slider-alt-bar, .enyo-progress-slider > .enyo-progress-bar-inner {
 	height: 10px;
 	border-width: 0 4px;
+	border-style: solid;
 	margin: 0 -4px;
 	position: absolute;
 	-webkit-border-image: url(palm/themes/Onyx/images/slider-progress.png) 0 4 0 4 repeat repeat;
@@ -1637,6 +1737,7 @@ html, body, input, button {
 
 .enyo-progress-slider-alt-bar {
 	z-index:5; /* under primary progress */
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/slider-progress-secondary.png) 0 4 0 4 repeat repeat;
 	-webkit-transition: width 0.3s ease;
 }
@@ -1645,14 +1746,17 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-slider {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/slider-track.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-slider > .enyo-progress-bar-inner {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/slider-progress.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-slider-alt-bar {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/slider-progress-secondary.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 }
 
@@ -1685,6 +1789,7 @@ html, body, input, button {
 .enyo-slider-progress {
 	height: 10px;
 	border-width: 0px 4px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/slider-track.png) 0 4 0 4 repeat repeat;
 	margin: 20px 0px;
 	position:relative;
@@ -1702,6 +1807,7 @@ html, body, input, button {
 	
 	.enyo-slider-progress {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/slider-track.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 }
 
@@ -1712,6 +1818,7 @@ html, body, input, button {
 	-webkit-box-sizing: border-box;
 	min-height: 50px;
 	border-width: 2px 0;
+	border-style: solid;
 	background-color: #ccc;
 	color: #444;
 	/*
@@ -1725,6 +1832,7 @@ html, body, input, button {
 
 .enyo-header.enyo-header-dark {
 	-webkit-border-image: url(palm/themes/Onyx/images/toolbar.png) 2 4 repeat stretch;
+	border-style: solid;
 	border-width: 2px 0;
 	background-color: #343434;
 	color: #fff;
@@ -1733,10 +1841,12 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-header {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/header.png) 3 0;
+		border-style: solid;
 	}
 	
 	.enyo-header.enyo-header-dark {
 		-webkit-border-image: url(palm/themes/Onyx/images/toolbar.png) 3 6 repeat stretch;
+		border-style: solid;
 	}
 }
 
@@ -1757,12 +1867,14 @@ html, body, input, button {
 	min-height: 54px;
 	-webkit-box-sizing: border-box;
 	-webkit-border-image: url(palm/themes/Onyx/images/toolbar.png) 2 4 repeat stretch;
+	border-style: solid;
 	border-width: 2px 4px;
 	background-color: #343434;
 }
 
 .enyo-toolbar-light {
 	-webkit-border-image: url(palm/themes/Onyx/images/toolbar-light.png) 2 4 repeat stretch;
+	border-style: solid;
 	background-color: #a9a9a9;
 }
 
@@ -1778,10 +1890,12 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-toolbar {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toolbar.png) 3 6 repeat stretch;
+		border-style: solid;
 	}
 	
 	.enyo-toolbar-light {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toolbar-light.png) 3 6 repeat stretch;
+		border-style: solid;
 	}
 }
 
@@ -1794,6 +1908,7 @@ html, body, input, button {
 .enyo-confirmprompt-scrim {
 	-webkit-border-image: url(palm/themes/Onyx/images/confirmprompt-background.png) 20 0 repeat;
 	-webkit-box-sizing: border-box;
+	border-style: solid;
 	border-width: 20px 0px;
 	background-color: #fff;
 }
@@ -1805,6 +1920,7 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-confirmprompt-scrim {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/confirmprompt-background.png) 30 0 stretch;
+		border-style: solid;
 	}
 }
 
@@ -1838,39 +1954,47 @@ html, body, input, button {
 
 .enyo-toggle-button-bar.on {
 	border-width: 0px 30px 0px 8px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/toggle-button.png) 1 30 97 8;
 }
 
 .enyo-toggle-button-bar.off {
 	border-width: 0px 8px 0px 30px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/toggle-button.png) 33 8 65 30;
 }
 
 .enyo-toggle-button-bar.disabled.on {
 	border-width: 0px 30px 0px 8px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/toggle-button.png) 65 30 33 8;
 }
 
 .enyo-toggle-button-bar.disabled.off {
 	border-width: 0px 8px 0px 30px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/toggle-button.png) 97 8 1 30;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-toggle-button-bar.on {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toggle-button.png) 2 45 145 12 stretch stretch;
+		border-style: solid;
 	}
 
 	.enyo-toggle-button-bar.off {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toggle-button.png) 50 12 97 45 stretch stretch;
+		border-style: solid;
 	}
 
 	.enyo-toggle-button-bar.disabled.on {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toggle-button.png) 98 45 49 12 stretch stretch;
+		border-style: solid;
 	}
 
 	.enyo-toggle-button-bar.disabled.off {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toggle-button.png) 146 12 1 45 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -1945,6 +2069,7 @@ html, body, input, button {
 
 .enyo-picker-button {
 	-webkit-border-image: url(palm/themes/Onyx/images/picker-pill.png) 10;
+	border-style: solid;
 	border-width: 10px;
 	font-size: 16px;
 	line-height: 32px;
@@ -1958,27 +2083,33 @@ html, body, input, button {
 
 .enyo-picker-button.enyo-button {
 	-webkit-border-image: url(palm/themes/Onyx/images/picker-pill.png) 10;
+	border-style: solid;
 }
 
 .enyo-picker-button.enyo-button-down {
 	-webkit-border-image: url(palm/themes/Onyx/images/picker-pill-downstate.png) 10;
+	border-style: solid;
 }
 
 .enyo-picker-button.enyo-button-focus {
 	-webkit-border-image: url(palm/themes/Onyx/images/picker-pill-focus.png) 10;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-picker-button {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/picker-pill.png) 15;
+		border-style: solid;
 	}
 
 	.enyo-picker-button.enyo-button-down {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/picker-pill-downstate.png) 15;
+		border-style: solid;
 	}
 
 	.enyo-picker-button.enyo-button-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/picker-pill-focus.png) 15;
+		border-style: solid;
 	}
 }
 
@@ -2008,6 +2139,7 @@ html, body, input, button {
 
 .enyo-pickergroup-pickerpopup {
 	border-width: 0;
+	border-style: solid;
 	-webkit-border-image: none;
 	min-width: 0px;
 }
@@ -2017,6 +2149,7 @@ html, body, input, button {
 
 .enyo-group {
 	border-width: 14px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/group-unlabeled.png) 14 14;
 	margin: 8px 3px;
 }
@@ -2031,6 +2164,7 @@ html, body, input, button {
 
 .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/group-labeled.png) 36 14 14 14;
 	margin: 8px 3px;
 }
@@ -2038,9 +2172,11 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-group {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/group-unlabeled.png) 21 21 stretch stretch;
+		border-style: solid;
 	}
 	.enyo-group.labeled {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/group-labeled.png) 54 21 21 21 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -2063,6 +2199,7 @@ html, body, input, button {
 
 .enyo-input.enyo-rounded-input, .enyo-input.enyo-rounded-input.enyo-input-focus {
 	border-width: 6px 20px;
+	border-style: solid;
 	-webkit-box-sizing: border-box;
 	-webkit-border-image: url(palm/themes/Onyx/images/roundedbox.png) 6 20;
 	margin: 2px 0;
@@ -2077,6 +2214,7 @@ html, body, input, button {
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-input.enyo-rounded-input, .enyo-input.enyo-rounded-input.enyo-input-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/roundedbox.png) 9 30;
+		border-style: solid;
 	}
 }
 
@@ -2093,11 +2231,13 @@ html, body, input, button {
 
 .enyo-input.enyo-input-focus {
 	-webkit-border-image: url(palm/themes/Onyx/images/input-focus.png) 14 14;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-input.enyo-input-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/input-focus.png) 21 21;
+		border-style: solid;
 	}
 }
 
@@ -2147,12 +2287,14 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-first.enyo-input.enyo-input-focus, .enyo-first > .enyo-input.enyo-input-focus {
 	padding-bottom: 12px;
 	border-width: 14px 14px 2px 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/input-first-focus.png) 14 14 2 14;
 }
 
 .enyo-last.enyo-input.enyo-input-focus, .enyo-last > .enyo-input.enyo-input-focus {
 	padding-top: 12px;
 	border-width: 2px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/input-last-focus.png) 2 14 14 14;
 }
 
@@ -2162,19 +2304,23 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-box-input.enyo-input.enyo-input-focus, .enyo-middle.enyo-input.enyo-input-focus, .enyo-middle > .enyo-input.enyo-input-focus {
 	background-color: transparent;
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/input-middle-focus.png) 14 14;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-first.enyo-input.enyo-input-focus, .enyo-first > .enyo-input.enyo-input-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/input-first-focus.png) 21 21 3 21;
+		border-style: solid;
 	}
 	.enyo-last.enyo-input.enyo-input-focus, .enyo-last > .enyo-input.enyo-input-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/input-last-focus.png) 3 21 21 21;
+		border-style: solid;
 	}
 	
 	.enyo-box-input.enyo-input.enyo-input-focus, .enyo-middle.enyo-input.enyo-input-focus, .enyo-middle > .enyo-input.enyo-input-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/input-middle-focus.png) 21 21;
+		border-style: solid;
 	}
 }
 
@@ -2217,14 +2363,17 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 
 .enyo-input.enyo-tool-input.enyo-input-focus {
 	-webkit-border-image: url(palm/themes/Onyx/images/input-tool-focus.png) 6 6 6 6;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-input.enyo-tool-input {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/input-tool.png) 9 9 9 9;
+		border-style: solid;
 	}
 	.enyo-input.enyo-tool-input.enyo-input-focus {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/input-tool-focus.png) 9 9 9 9;
+		border-style: solid;
 	}
 }
 
@@ -2307,6 +2456,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 	right: 0px;
 	bottom: 0;
 	border-width: 32px 24px 32px 24px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/toaster-dialog.png) 32 24 32 24 stretch stretch;
 }
 
@@ -2318,6 +2468,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-toaster-dialog {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/toaster-dialog.png) 48 36 48 36 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -2425,6 +2576,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-webview-popup-spinner {
 	min-width: 0px;
 	-webkit-border-image: none;
+	border-style: solid;
 }
 
 
@@ -2433,6 +2585,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-modaldialog {
 	width: 320px;
 	border-width: 42px 24px 24px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/dialog.png) 42 24 24 24 stretch stretch;
 	-webkit-transition-property: opacity;
 	-webkit-transition-duration: 0.5s;
@@ -2454,26 +2607,31 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-modaldialog-container .enyo-group,
 .enyo-modaldialog-container .group {
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/dialog-group-unlabeled.png) 14 14 repeat repeat;
 	margin: 8px 0;
 }
 .enyo-modaldialog-container .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/dialog-group-labeled.png) 36 14 14 14 repeat repeat;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-modaldialog {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/dialog.png) 63 36 36 36 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-modaldialog-container .enyo-group,
 	.enyo-modaldialog-container .group {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/dialog-group-unlabeled.png) 21 21 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-modaldialog-container .enyo-group.labeled {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/dialog-group-labeled.png) 54 21 21 21 stretch stretch;
+		border-style: solid;
 	}
 }
 
@@ -2484,6 +2642,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-filepicker {
 	width: 450px;
 	border-width: 24px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/filepicker.png) 25 stretch stretch;
 }
 
@@ -2499,27 +2658,32 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-filepicker-mainview .enyo-group,
 .enyo-filepicker-mainview .group {
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/dialog-group-unlabeled.png) 14 14 repeat repeat;
 	margin: 8px 0;
 }
 
 .enyo-filepicker-mainview .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(palm/themes/Onyx/images/dialog-group-labeled.png) 36 14 14 14 repeat repeat;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-filepicker {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/filepicker.png) 36 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-filepicker-mainview .enyo-group,
 	.enyo-filepicker-mainview .group {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/modaldialog-group-unlabeled.png) 21 21 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-filepicker-mainview .enyo-group.labeled {
 		-webkit-border-image: url(palm/themes/Onyx/images-1.5/modaldialog-group-labeled.png) 54 21 21 21 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/build/palm/system/dashboard-window/dashboard.css
+++ b/framework/build/palm/system/dashboard-window/dashboard.css
@@ -90,11 +90,13 @@ body {
 	-webkit-border-image: url(images/dashboard-newitem-badge.png) 0 12 28 12 repeat stretch;
 	-webkit-box-sizing: border-box;
 	border-width: 0px 12px 0px 12px;
+	border-style: solid;
 }
 
 .palm-dashboard-icon-container:active .dashboard-newitem,
 .palm-dashboard-icon-container.selected .dashboard-newitem {
 	-webkit-border-image: url(images/dashboard-newitem-badge.png) 28 12 0 12 repeat stretch;
+	border-style: solid;
 }
 
 .dashboard-count-label {

--- a/framework/lib/authlib/dialpadwidget/dialpad.css
+++ b/framework/lib/authlib/dialpadwidget/dialpad.css
@@ -116,6 +116,7 @@
 .dialpadbutton-top-middle.enyo-button-down,
 .dialpadbutton-top-left.enyo-button-down  {
 	-webkit-border-image: url(../images/pin-key-highlight.png) 1 0 1 0;
+	border-style: solid;
 }
 .dialpadbutton-left.enyo-button-down,
 .dialpadbutton-middle.enyo-button-down,
@@ -139,20 +140,24 @@
 .dial-button {
 	height: 66px;
 	border-width: 0 26px;
+	border-style: solid;
 	-webkit-border-image: url(images/dial-button.png) 0 26 132 26 repeat repeat;
 }
 
 .dial-button.enyo-button-down {
 	-webkit-border-image: url(images/dial-button.png) 132 26 0 26 repeat repeat;
+	border-style: solid;
 }
 
 .dial-button.enyo-button-disabled {
 	-webkit-border-image: url(images/dial-button.png) 66 26 66 26 repeat repeat;
+	border-style: solid;
 }
 
 .pin-menu-button {
 	height: 60px;
 	-webkit-border-image: url(images/pin-menu-button-tall.png) 0 25 60 25 repeat repeat;
+	border-style: solid;
 	border-width: 0 25px 0 25px;
 	font-size: 16px;
 	color: white;
@@ -160,6 +165,7 @@
 
 .pin-menu-button.enyo-button-down {
 	-webkit-border-image: url(images/pin-menu-button-tall.png) 60 25 0 25 repeat repeat;
+	border-style: solid;
 }
 
 .pinCardBackground {

--- a/framework/lib/authlib/styles.css
+++ b/framework/lib/authlib/styles.css
@@ -59,6 +59,7 @@
 	-webkit-border-image: url(images/popup-bg.png) 20 20 20 20 stretch stretch;
 	-webkit-box-sizing: border-box;
 	border-width: 20px;
+	border-style: solid;
 	left: 0px;
 	min-width: 300px;
 	position: fixed;

--- a/framework/lib/contactsui/css/contactsui.css
+++ b/framework/lib/contactsui/css/contactsui.css
@@ -14,6 +14,7 @@
 .enyo-contacts-list .contacts-search.enyo-input.enyo-rounded-input {
 	margin:0 0 -3px; /* blend shadow from bg_search.png */
 	-webkit-border-image:url(../images/bg_search.png) 0 15 repeat;
+	border-style: solid;
 	border-width:0 15px;	
 	height:44px;
 }
@@ -166,6 +167,7 @@
 }
 .enyo-contacts-details .enyo-group {
 	-webkit-border-image:none;
+	border-style: solid;
 	border:0;
 	border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 	border-top:1px solid (255,255,255,0.2);
@@ -226,6 +228,7 @@
 .edit-contact.enyo-button {
 	background:none;
 	-webkit-border-image:none;
+	border-style: solid;
 }
 /* TODO: temporary styling to be replaced...all GAL styling TDB*/
 .contacts-GAL-message {
@@ -252,6 +255,7 @@
 .contactsui-peoplepicker {
   width: 320px;
   border-width: 24px;
+  border-style: solid;
   -webkit-border-image: url(../images/dialogbg.png) 24 stretch stretch;
 }
 

--- a/framework/lib/palmstyle/css/palm.css
+++ b/framework/lib/palmstyle/css/palm.css
@@ -6,6 +6,7 @@
 
 .enyo-header.palm-dark-header {
 	border-width: 1px 4px;
+	border-style: solid;
 	background-color: #343434;
 	-webkit-border-image: url(../../../source/palm/themes/Onyx/images/toolbar.png) 1 4 repeat stretch;
 }
@@ -39,6 +40,7 @@
 }
 .palm-modal-dialog-content .group {
 	-webkit-border-image: url(../images/bg_rowgroup.png) 10 10 repeat;
+	border-style: solid;
 	border-width: 10px;
 	margin-bottom: 10px;
 }

--- a/framework/lib/telephony/dialpad/dialpad.css
+++ b/framework/lib/telephony/dialpad/dialpad.css
@@ -52,6 +52,7 @@
 	padding: 0;
 	background: none;
 	-webkit-border-image:none;
+	border-style: solid;
 }
 
 .dialpadbutton-bottom-back.enyo-button-down{
@@ -59,6 +60,7 @@
 	min-width: 0;
 	padding: 0;
 	-webkit-border-image:none;
+	border-style: solid;
 }
 .dialpad-backspace .enyo-button-icon {
 	margin-bottom: 0px;
@@ -116,6 +118,7 @@
 .dialpadbutton-top-middle.enyo-button-down,
 .dialpadbutton-top-left.enyo-button-down  {
 	-webkit-border-image: url(images/pin-key-highlight.png) 1 0 1 0;
+	border-style: solid;
 }
 .dialpadbutton-left.enyo-button-down,
 .dialpadbutton-middle.enyo-button-down,
@@ -139,15 +142,18 @@
 .dial-button {
 	height: 66px;
 	border-width: 0 26px;
+	border-style: solid;
 	-webkit-border-image: url(images/dial-button.png) 0 26 132 26 repeat repeat;
 }
 
 .dial-button.enyo-button-down {
 	-webkit-border-image: url(images/dial-button.png) 132 26 0 26 repeat repeat;
+	border-style: solid;
 }
 
 .dial-button.enyo-button-disabled {
 	-webkit-border-image: url(images/dial-button.png) 66 26 66 26 repeat repeat;
+	border-style: solid;
 }
 .pinCardBackground {
 	background: url(images/backdrop-firstuse.png) top left;
@@ -163,6 +169,7 @@
 .cust-enyo-popup{
 	-webkit-border-image: url(images/popup-bg.png) 20 20 20 20;
 	-webkit-box-sizing: border-box;
+	border-style: solid;
 	border-width: 20px;
 	left: 0px;
 	min-width: 355px;

--- a/framework/source/palm/system/dashboard-window/dashboard.css
+++ b/framework/source/palm/system/dashboard-window/dashboard.css
@@ -90,11 +90,13 @@ body {
 	-webkit-border-image: url(images/dashboard-newitem-badge.png) 0 12 28 12 repeat stretch;
 	-webkit-box-sizing: border-box;
 	border-width: 0px 12px 0px 12px;
+	border-style: solid;
 }
 
 .palm-dashboard-icon-container:active .dashboard-newitem,
 .palm-dashboard-icon-container.selected .dashboard-newitem {
 	-webkit-border-image: url(images/dashboard-newitem-badge.png) 28 12 0 12 repeat stretch;
+	border-style: solid;
 }
 
 .dashboard-count-label {

--- a/framework/source/palm/themes/Heritage/css/AlertButton.css
+++ b/framework/source/palm/themes/Heritage/css/AlertButton.css
@@ -14,10 +14,12 @@
 .enyo-alert-button {
 	background-color: #c70000;
 	-webkit-border-image: url(../images/alert-button.png) 0 14 111 14 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-alert-button.enyo-button-down {
 	-webkit-border-image: url(../images/alert-button.png) 37 14 74 14 repeat repeat;
+	border-style: solid;
 }
 
 /* undo button (often cancel) */
@@ -25,8 +27,10 @@
 .enyo-alert-button-undo {
 	background-color: white;
 	-webkit-border-image: url(../images/alert-button.png) 74 14 37 14 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-alert-button-undo.enyo-button-down {
 	-webkit-border-image: url(../images/alert-button.png) 111 14 0 14 repeat repeat;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/AppMenu.css
+++ b/framework/source/palm/themes/Heritage/css/AppMenu.css
@@ -3,6 +3,7 @@
 	position: fixed;
 	font-size: 18px;
 	border-width: 30px 28px 35px 28px;
+	border-style: solid;
 	-webkit-border-image: url(../images/system-menu-background.png) 30 28 35 28 stretch stretch;
 	color: white;
 	top: -2px;
@@ -25,6 +26,7 @@
 */
 .enyo-appmenu .enyo-item {
 	-webkit-border-image: url(../images/system-menu-item-divider.png) 1 0 1 0 stretch;
+	border-style: solid;
 	border-bottom: 0px;
 }
 

--- a/framework/source/palm/themes/Heritage/css/Button.css
+++ b/framework/source/palm/themes/Heritage/css/Button.css
@@ -24,18 +24,22 @@
 
 .enyo-button {
 	-webkit-border-image: url(../images/palm-button-medium.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button.enyo-button-down {
 	-webkit-border-image: url(../images/palm-button-medium.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-button-medium.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-medium.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* light button (often cancel) */
@@ -43,15 +47,18 @@
 .enyo-button-light {
 	color: #332;
 	-webkit-border-image: url(../images/palm-button-light.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-light.enyo-button-down {
 	-webkit-border-image: url(../images/palm-button-light.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-light.enyo-button-disabled {
 	color: #777;
 	-webkit-border-image: url(../images/palm-button-light.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* affirmative (green) */
@@ -59,14 +66,17 @@
 .enyo-button-affirmative {
 	color: #fff;
 	-webkit-border-image: url(../images/palm-button-affirmative.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-affirmative.enyo-button-down {
 	-webkit-border-image: url(../images/palm-button-affirmative.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-affirmative.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-affirmative.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* negative (red) */
@@ -74,42 +84,51 @@
 .enyo-button-negative {
 	color: #fff;
 	-webkit-border-image: url(../images/palm-button-negative.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-negative.enyo-button-down {
 	-webkit-border-image: url(../images/palm-button-negative.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-negative.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-negative.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* dark */
 
 .enyo-button-dark {
 	-webkit-border-image: url(../images/palm-button-dark.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-dark.enyo-button-down {
 	-webkit-border-image: url(../images/palm-button-dark.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-button-dark.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-dark.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* notification button */
 
 .enyo-notification-button {
 	-webkit-border-image: url(../images/palm-button-medium.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button.enyo-button-down, .enyo-notification-button.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-button-medium.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-medium.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* notification button (affirmative) */
@@ -117,40 +136,49 @@
 .enyo-notification-button-affirmative {
 	color: #fff;
 	-webkit-border-image: url(../images/palm-button-affirmative.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button-affirmative.enyo-button-down, .enyo-notification-button-affirmative.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-button-affirmative.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button-affirmative.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-affirmative.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 /* notification button (negative) */
 
 .enyo-notification-button-negative {
 	color: #fff;
 	-webkit-border-image: url(../images/palm-button-negative.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button-negative.enyo-button-down, .enyo-notification-button-negative.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-button-negative.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button-negative.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-negative.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }
 
 /* notification button (alternate) */
 
 .enyo-notification-button-alternate {
 	-webkit-border-image: url(../images/palm-button-dark.png) 0 17 104 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button-alternate.enyo-button-down, .enyo-notification-button-alternate.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-button-dark.png) 52 17 52 17 repeat repeat;
+	border-style: solid;
 }
 
 .enyo-notification-button-alternate.enyo-button-disabled {
 	-webkit-border-image: url(../images/palm-button-dark.png) 104 17 0 17 repeat repeat;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/ButtonHeader.css
+++ b/framework/source/palm/themes/Heritage/css/ButtonHeader.css
@@ -16,16 +16,20 @@
 
 .enyo-button-header.enyo-button {
 	-webkit-border-image: url(../images/palm-menu-button.png) 0 25 200 25;
+	border-style: solid;
 }
 
 .enyo-button-header.enyo-button-down {
 	-webkit-border-image: url(../images/palm-menu-button.png) 50 25 150 25;
+	border-style: solid;
 }
 
 .enyo-button-header.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-menu-button.png) 100 25 100 25;
+	border-style: solid;
 }
 
 .enyo-button-header.enyo-button-depressed.enyo-button-down {
 	-webkit-border-image: url(../images/palm-menu-button.png) 150 25 50 25;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/Divider.css
+++ b/framework/source/palm/themes/Heritage/css/Divider.css
@@ -13,6 +13,7 @@
 .enyo-divider-left-cap {
 	min-width: 4px;
 	border-width: 0px;
+	border-style: solid;
 	-webkit-border-image: url(../images/enyo-divider-border.png) 0 6 0 6 repeat repeat;
 }
 

--- a/framework/source/palm/themes/Heritage/css/FancyInput.css
+++ b/framework/source/palm/themes/Heritage/css/FancyInput.css
@@ -34,6 +34,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 	padding-bottom: 11px;
 	border-width: 14px 14px 3px 14px;
 	border-image: url(../images/roundy-shadow-top.png) 14 14 3 14;
+	border-style: solid;
 	-webkit-border-image: url(../images/roundy-shadow-top.png) 14 14 3 14;
 	-moz-border-image: url(../images/roundy-shadow-top.png) 14 14 3 14;
 }
@@ -42,6 +43,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 	padding-top: 11px;
 	border-width: 3px 14px 14px 14px;
 	border-image: url(../images/roundy-shadow-bottom.png) 3 14 14 14;
+	border-style: solid;
 	-webkit-border-image: url(../images/roundy-shadow-bottom.png) 3 14 14 14;
 	-moz-border-image: url(../images/roundy-shadow-bottom.png) 3 14 14 14;
 }
@@ -49,6 +51,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .rounded.enyo-single > .enyo-flat-shadow {
 	border-width: 14px 14px 14px 14px;
 	border-image: url(../images/roundy-shadow.png) 14 14;
+	border-style: solid;
 	-webkit-border-image: url(../images/roundy-shadow.png) 14 14;
 	-moz-border-image: url(../images/roundy-shadow.png) 14 14;
 }
@@ -58,6 +61,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-flat-shadow {
 	background-color: transparent;
 	border-width: 14px;
+	border-style: solid;
 	border-image: url(../images/flat-shadow.png) 14 14;
 	-webkit-border-image: url(../images/flat-shadow.png) 14 14;
 	-moz-border-image: url(../images/flat-shadow.png) 14 14;
@@ -67,6 +71,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 	background-color: transparent;
 	padding-bottom: 11px;
 	border-width: 14px 14px 3px 14px;
+	border-style: solid;
 	border-image: url(../images/roundy-shadow-top.png) 14 14 3 14;
 	-webkit-border-image: url(../images/roundy-shadow-top.png) 14 14 3 14;
 	-moz-border-image: url(../images/roundy-shadow-top.png) 14 14 3 14;
@@ -80,6 +85,7 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 	background-color: transparent;
 	padding-top: 11px;
 	border-width: 3px 14px 14px 14px;
+	border-style: solid;
 	border-image: url(../images/roundy-shadow-bottom.png) 3 14 14 14;
 	-webkit-border-image: url(../images/roundy-shadow-bottom.png) 3 14 14 14;
 	-moz-border-image: url(../images/roundy-shadow-bottom.png) 3 14 14 14;

--- a/framework/source/palm/themes/Heritage/css/Group.css
+++ b/framework/source/palm/themes/Heritage/css/Group.css
@@ -1,5 +1,6 @@
 .enyo-group {
 	border-width: 14px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/group.png) 14 14;
 	-moz-border-image: url(../images/group.png) 14 14;
 	border-image: url(../images/group.png) 14 14;
@@ -16,6 +17,7 @@
 
 .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/group-labeled.png) 36 14 14 14;
 	-moz-border-image: url(../images/group-labeled.png) 36 14 14 14;
 	border-image: url(../images/group-labeled.png) 36 14 14 14;

--- a/framework/source/palm/themes/Heritage/css/GroupedToolButton.css
+++ b/framework/source/palm/themes/Heritage/css/GroupedToolButton.css
@@ -19,91 +19,111 @@
 .enyo-grouped-toolbutton.enyo-first {
 	padding: 0px 13px 0px 0px;
 	border-width: 0px 1px 0px 23px;
+	border-style: solid;
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 0 1 950 23;
 }
 
 .enyo-grouped-toolbutton.enyo-middle {
 	padding: 0px 14px 0px 14px;
 	border-width: 0px 1px 0px 1px;
+	border-style: solid;
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 250 1 700 1;
 }
 
 .enyo-grouped-toolbutton.enyo-single {
 	padding: 0px 14px 0px 14px;
 	border-width: 0px 23px 0px 23px;
+	border-style: solid;
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 750 23 200 23;
 }
 
 .enyo-grouped-toolbutton.enyo-last {
 	padding: 0px 0px 0px 13px;
 	border-width: 0px 23px 0px 1px;
+	border-style: solid;
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 500 23 450 1;
 }
 
 /* down */
 .enyo-grouped-toolbutton.enyo-first.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 50 1 900 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-middle.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 300 1 650 1;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-single.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 800 23 150 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-last.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 550 23 400 1;
+	border-style: solid;
 }
 
 /* depressed */
 .enyo-grouped-toolbutton.enyo-first.enyo-button-depressed {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 100 1 850 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-middle.enyo-button-depressed {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 350 1 600 1;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-single.enyo-button-depressed {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 850 23 100 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-last.enyo-button-depressed {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 600 23 350 1;
+	border-style: solid;
 }
 
 /* depressed + down */
 .enyo-grouped-toolbutton.enyo-first.enyo-button-depressed.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 150 1 800 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-middle.enyo-button-depressed.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 400 1 550 1;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-single.enyo-button-depressed.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 900 23 50 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-last.enyo-button-depressed.enyo-button-down {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 650 23 300 1;
+	border-style: solid;
 }
 
 /* disabled */
 .enyo-grouped-toolbutton.enyo-first.enyo-button-disabled {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 200 1 750 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-middle.enyo-button-disabled {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 450 1 500 1;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-single.enyo-button-disabled {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 950 23 0 23;
+	border-style: solid;
 }
 
 .enyo-grouped-toolbutton.enyo-last.enyo-button-disabled {
 	-webkit-border-image: url(../images/grouped-toolbutton.png) 700 23 250 1;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/Header.css
+++ b/framework/source/palm/themes/Heritage/css/Header.css
@@ -1,5 +1,6 @@
 .enyo-header {
 	border-width: 35px 24px 13px 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/palm-page-header.png) 35 24 13 24 repeat stretch;
 	-webkit-box-sizing: border-box;
 	min-height: 50px;

--- a/framework/source/palm/themes/Heritage/css/Input.css
+++ b/framework/source/palm/themes/Heritage/css/Input.css
@@ -7,6 +7,7 @@
 
 .enyo-input-focus {
 	-webkit-border-image: url(../images/input-middle-focus.png) 14 14;
+	border-style: solid;
 }
 
 .enyo-input-input {
@@ -39,17 +40,20 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-first.enyo-input-focus {
 	padding-bottom: 11px;
 	border-width: 14px 14px 3px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/input-first-focus.png) 14 14 3 14;
 }
 
 .enyo-last.enyo-input-focus {
 	padding-top: 11px;
 	border-width: 3px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/input-last-focus.png) 3 14 14 14;
 }
 
 .enyo-single.enyo-input-focus {
 	background-color: transparent;
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/input-focus.png) 14 14;
 }

--- a/framework/source/palm/themes/Heritage/css/MenuInput.css
+++ b/framework/source/palm/themes/Heritage/css/MenuInput.css
@@ -2,11 +2,13 @@
 	height: 50px;
 	line-height: 50px;
 	border-width: 0 25px;
+	border-style: solid;
 	-webkit-border-image: url(../images/palm-menu-input.png) 0 25 50 25 stretch stretch;
 }
 
 .enyo-menu-input-focus {
 	-webkit-border-image: url(../images/palm-menu-input.png) 50 25 0 25 stretch stretch;
+	border-style: solid;
 }
 
 .enyo-menu-input-inner {

--- a/framework/source/palm/themes/Heritage/css/Picker.css
+++ b/framework/source/palm/themes/Heritage/css/Picker.css
@@ -10,6 +10,7 @@
 	font-size: inherited;
 	border-width: 19px;
 	-webkit-border-image: url(../images/popup-picker.png) 19;
+	border-style: solid;
 }
 
 .enyo-picker-item-selected {

--- a/framework/source/palm/themes/Heritage/css/PickerButton.css
+++ b/framework/source/palm/themes/Heritage/css/PickerButton.css
@@ -1,6 +1,7 @@
 .enyo-picker-button {
 	-webkit-border-image: url(../images/background-pill.png) 19;
 	border-width: 19px;
+	border-style: solid;
 	margin: 0 5px -2px -1px;
 }
 
@@ -15,12 +16,15 @@
 
 .enyo-picker-button.enyo-button {
 	-webkit-border-image: url(../images/background-pill.png) 19;
+	border-style: solid;
 }
 
 .enyo-picker-button.enyo-button-down {
 	-webkit-border-image: url(../images/background-pill-downstate.png) 19;
+	border-style: solid;
 }
 
 .enyo-picker-button.enyo-button-focus {
 	-webkit-border-image: url(../images/background-pill-focus.png) 19;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/Popup.css
+++ b/framework/source/palm/themes/Heritage/css/Popup.css
@@ -7,6 +7,7 @@
 	/*font-size: 16px;*/
 	-webkit-box-sizing: border-box;
 	border-width: 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/popup-heritage.png) 24 24 24 24 stretch stretch;
 }
 

--- a/framework/source/palm/themes/Heritage/css/ProgressBar.css
+++ b/framework/source/palm/themes/Heritage/css/ProgressBar.css
@@ -1,6 +1,7 @@
 .enyo-progress-bar {
 	height: 11px;
 	border-width: 0 6px;
+	border-style: solid;
 	-webkit-border-image: url(../images/progress-bar.png) 0 6 0 6 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -10,6 +11,7 @@
 	margin: 0 -6px;
 	height: 11px;
 	border-width: 0 6px;
+	border-style: solid;
 	position: absolute;
 	-webkit-border-image: url(../images/progress-bar-inner.png) 0 6 0 6 repeat repeat;
 }

--- a/framework/source/palm/themes/Heritage/css/ProgressButton.css
+++ b/framework/source/palm/themes/Heritage/css/ProgressButton.css
@@ -1,6 +1,7 @@
 .enyo-progress-button {
 	height: 50px;
 	border-width: 0px 25px;
+	border-style: solid;
 	-webkit-border-image: url(../images/palm-menu-button.png) 0 25 200 25;
 	-webkit-box-sizing: border-box;
 	color: white;
@@ -11,6 +12,7 @@
 	height: 50px;
 	margin: 0 -25px;
 	border-width: 0 25px;
+	border-style: solid;
 	position: absolute;
 	-webkit-border-image: url(../images/progress-button-inner.png) 0 25 0 25 repeat repeat;
 }

--- a/framework/source/palm/themes/Heritage/css/RadioButton.css
+++ b/framework/source/palm/themes/Heritage/css/RadioButton.css
@@ -20,24 +20,28 @@
 .enyo-tabbutton.enyo-last {
 	padding: 0px 13px 0px 14px;
 	border-width: 0px 2px 0px 1px;
+	border-style: solid;
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 150 2 400 1;
 }
 
 .enyo-radiobutton.enyo-single, .enyo-tabbutton.enyo-single {
 	padding: 0px 13px 0px 14px;
 	border-width: 0px 15px 0px 15px;
+	border-style: solid;
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 450 15 100 15;
 }
 
 .enyo-radiobutton.enyo-first {
 	padding: 0px 13px 0px 0px;
 	border-width: 0px 2px 0px 15px;
+	border-style: solid;
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 0 2 550 15;
 }
 
 .enyo-radiobutton.enyo-last {
 	padding: 0px 0px 0px 13px;
 	border-width: 0px 15px 0px 1px;
+	border-style: solid;
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 300 15 250 1;
 }
 
@@ -61,6 +65,7 @@
 .enyo-tabbutton.enyo-last.enyo-button-depressed,
 .enyo-tabbutton.enyo-last.enyo-button-down {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 200 2 350 1;
+	border-style: solid;
 }
 
 .enyo-radiobutton.enyo-single.enyo-button-depressed,
@@ -68,16 +73,19 @@
 .enyo-tabbutton.enyo-single.enyo-button-depressed,
 .enyo-tabbutton.enyo-single.enyo-button-down {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 500 15 50 15;
+	border-style: solid;
 }
 
 .enyo-radiobutton.enyo-first.enyo-button-depressed,
 .enyo-radiobutton.enyo-first.enyo-button-down {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 50 2 500 15;
+	border-style: solid;
 }
 
 .enyo-radiobutton.enyo-last.enyo-button-depressed,
 .enyo-radiobutton.enyo-last.enyo-button-down {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 350 15 200 1;
+	border-style: solid;
 }
 
 /* disabled */
@@ -87,17 +95,21 @@
 .enyo-tabbutton.enyo-middle.enyo-button-disabled,
 .enyo-tabbutton.enyo-last.enyo-button-disabled {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 250 2 300 1;
+	border-style: solid;
 }
 
 .enyo-radiobutton.enyo-single.enyo-button-disabled,
 .enyo-tabbutton.enyo-single.enyo-button-disabled {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 550 15 0 15;
+	border-style: solid;
 }
 
 .enyo-radiobutton.enyo-first.enyo-button-disabled {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 100 2 450 15;
+	border-style: solid;
 }
 
 .enyo-radiobutton.enyo-last.enyo-button-disabled {
 	-webkit-border-image: url(../images/radiobutton-heritage.png) 400 15 150 1;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/Recessed.css
+++ b/framework/source/palm/themes/Heritage/css/Recessed.css
@@ -8,6 +8,7 @@
 	background-color: transparent;
 	border-width: 14px 14px 14px 14px;
 	border-image: url(../images/roundy-shadow.png) 14 14;
+	border-style: solid;
 	-webkit-border-image: url(../images/roundy-shadow.png) 14 14;
 	-moz-border-image: url(../images/roundy-shadow.png) 14 14;
 }

--- a/framework/source/palm/themes/Heritage/css/Slider.css
+++ b/framework/source/palm/themes/Heritage/css/Slider.css
@@ -23,6 +23,7 @@
 .enyo-slider-progress {
 	height: 7px;
 	border-width: 0px 4px;
+	border-style: solid;
 	-webkit-border-image: url(../images/slider.png) 0 4 0 4 repeat repeat;
 	margin: 22px 25px 21px;
 	position:relative;

--- a/framework/source/palm/themes/Heritage/css/ToggleButton.css
+++ b/framework/source/palm/themes/Heritage/css/ToggleButton.css
@@ -8,21 +8,25 @@
 
 .enyo-toggle-button.on {
 	border-width: 0px 36px 0px 15px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 1 36 97 15 repeat repeat;
 }
 
 .enyo-toggle-button.off {
 	border-width: 0px 15px 0px 36px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 33 15 65 36 repeat repeat;
 }
 
 .enyo-toggle-button.disabled.on {
 	border-width: 0px 36px 0px 15px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 65 36 33 15 repeat repeat;
 }
 
 .enyo-toggle-button.disabled.off {
 	border-width: 0px 15px 0px 36px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 97 15 1 36 repeat repeat;
 }
 

--- a/framework/source/palm/themes/Heritage/css/ToolButton.css
+++ b/framework/source/palm/themes/Heritage/css/ToolButton.css
@@ -24,16 +24,20 @@
 
 .enyo-tool-button, .enyo-tool-button.enyo-tool-button-captioned {
 	-webkit-border-image: url(../images/palm-menu-button.png) 0 25 200 25;
+	border-style: solid;
 }
 
 .enyo-tool-button.enyo-button-down {
 	-webkit-border-image: url(../images/palm-menu-button.png) 50 25 150 25;
+	border-style: solid;
 }
 
 .enyo-tool-button.enyo-button-depressed {
 	-webkit-border-image: url(../images/palm-menu-button.png) 100 25 100 25;
+	border-style: solid;
 }
 
 .enyo-tool-button.enyo-button-depressed.enyo-button-down {
 	-webkit-border-image: url(../images/palm-menu-button.png) 150 25 50 25;
+	border-style: solid;
 }

--- a/framework/source/palm/themes/Heritage/css/ToolInput.css
+++ b/framework/source/palm/themes/Heritage/css/ToolInput.css
@@ -1,11 +1,13 @@
 .enyo-tool-input {
 	height: 50px;
 	border-width: 0 25px;
+	border-style: solid;
 	-webkit-border-image: url(../images/palm-menu-input.png) 0 25 50 25 stretch stretch;
 }
 
 .enyo-tool-input-focus {
 	-webkit-border-image: url(../images/palm-menu-input.png) 50 25 0 25 stretch stretch;
+	border-style: solid;
 }
 
 .enyo-tool-input-input {

--- a/framework/source/palm/themes/Onyx/css/AppMenu.css
+++ b/framework/source/palm/themes/Onyx/css/AppMenu.css
@@ -3,6 +3,7 @@
 	position: fixed;
 	font-size: 18px;
 	border-width: 12px 24px 20px 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/appmenu.png) 12 24 20 24 stretch stretch;
 	color: white;
 	top: 0px;
@@ -32,5 +33,6 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-popup.enyo-appmenu {
 		-webkit-border-image: url(../images-1.5/appmenu.png) 18 36 30 36 stretch stretch;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/AppMenuItem.css
+++ b/framework/source/palm/themes/Onyx/css/AppMenuItem.css
@@ -2,6 +2,7 @@
 	-webkit-border-image: url(../images/appmenu-divider.png) 0 0 2 0 stretch;
 	color: white;
 	border-bottom: 2px;
+	border-style: solid;
 	padding: 10px 7px 10px 5px;
 	font-size: 18px;
 }
@@ -19,10 +20,12 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-appmenu-item.enyo-item { 
 		-webkit-border-image: url(../images-1.5/appmenu-divider.png) 0 0 3 0 stretch;
+		border-style: solid;
 	}
 	
 	.enyo-appmenu-item.enyo-held {
 		background-image: url(../images-1.5/appmenu-highlight.png);
+		border-style: solid;
 	}
 	
 }

--- a/framework/source/palm/themes/Onyx/css/Button.css
+++ b/framework/source/palm/themes/Onyx/css/Button.css
@@ -11,6 +11,7 @@
 	-webkit-border-image: url(../images/button-up.png) 4 4 4 4 stretch stretch;
 	border-width: 4px;
 	border-radius: 5px;
+	border-style: solid;
 	margin: 3px;
 	color: #292929;
 	background-color: rgba(255,255,255,0.8);
@@ -18,15 +19,18 @@
 
 .enyo-button.enyo-button-down, .enyo-button.enyo-button-depressed {
 	-webkit-border-image: url(../images/button-down.png) 4 4 4 4 stretch stretch;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-button {
 		-webkit-border-image: url(../images-1.5/button-up.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-button.enyo-button-down, .enyo-button.enyo-button-depressed {
 		-webkit-border-image: url(../images-1.5/button-down.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/ConfirmPrompt.css
+++ b/framework/source/palm/themes/Onyx/css/ConfirmPrompt.css
@@ -6,6 +6,7 @@
 	-webkit-border-image: url(../images/confirmprompt-background.png) 20 0 repeat;
 	-webkit-box-sizing: border-box;
 	border-width: 20px 0px;
+	border-style: solid;
 	background-color: #fff;
 }
 
@@ -16,5 +17,6 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-confirmprompt-scrim {
 		-webkit-border-image: url(../images-1.5/confirmprompt-background.png) 30 0 stretch;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/Dialog.css
+++ b/framework/source/palm/themes/Onyx/css/Dialog.css
@@ -3,6 +3,7 @@
 	right: 0px;
 	bottom: 0;
 	border-width: 32px 24px 32px 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toaster-dialog.png) 32 24 32 24 stretch stretch;
 }
 
@@ -14,5 +15,6 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-toaster-dialog {
 		-webkit-border-image: url(../images-1.5/toaster-dialog.png) 48 36 48 36 stretch stretch;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/FilePicker.css
+++ b/framework/source/palm/themes/Onyx/css/FilePicker.css
@@ -1,6 +1,7 @@
 .enyo-filepicker {
 	width: 450px;
 	border-width: 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/filepicker.png) 25 stretch stretch;
 }
 
@@ -16,27 +17,32 @@
 .enyo-filepicker-mainview .enyo-group,
 .enyo-filepicker-mainview .group {
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/dialog-group-unlabeled.png) 14 14 repeat repeat;
 	margin: 8px 0;
 }
 
 .enyo-filepicker-mainview .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/dialog-group-labeled.png) 36 14 14 14 repeat repeat;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-filepicker {
 		-webkit-border-image: url(../images-1.5/filepicker.png) 36 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-filepicker-mainview .enyo-group,
 	.enyo-filepicker-mainview .group {
 		-webkit-border-image: url(../images-1.5/modaldialog-group-unlabeled.png) 21 21 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-filepicker-mainview .enyo-group.labeled {
 		-webkit-border-image: url(../images-1.5/modaldialog-group-labeled.png) 54 21 21 21 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/Group.css
+++ b/framework/source/palm/themes/Onyx/css/Group.css
@@ -1,5 +1,6 @@
 .enyo-group {
 	border-width: 14px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/group-unlabeled.png) 14 14;
 	margin: 8px 3px;
 }
@@ -14,6 +15,7 @@
 
 .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/group-labeled.png) 36 14 14 14;
 	margin: 8px 3px;
 }
@@ -21,9 +23,11 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-group {
 		-webkit-border-image: url(../images-1.5/group-unlabeled.png) 21 21 stretch stretch;
+		border-style: solid;
 	}
 	.enyo-group.labeled {
 		-webkit-border-image: url(../images-1.5/group-labeled.png) 54 21 21 21 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/GroupedToolButton.css
+++ b/framework/source/palm/themes/Onyx/css/GroupedToolButton.css
@@ -29,76 +29,92 @@
 
 	.enyo-grouped-toolbutton.enyo-first {
 		-webkit-border-image: url(../images/radiobutton.png) 0 16 556 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 37 16 519 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle {
 		-webkit-border-image: url(../images/radiobutton.png) 74 16 482 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 111 16 445 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last {
 		-webkit-border-image: url(../images/radiobutton.png) 148 16 408 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 185 16 371 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single {
 		-webkit-border-image: url(../images/radiobutton.png) 222 16 334 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 259 16 297 16;
+		border-style: solid;
 	}
 
 	/* dark */
 
 	.enyo-grouped-toolbutton-dark.enyo-first {
 		-webkit-border-image: url(../images/radiobutton.png) 296 16 260 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 333 16 223 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle {
 		-webkit-border-image: url(../images/radiobutton.png) 370 16 186 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 407 16 149 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last {
 		-webkit-border-image: url(../images/radiobutton.png) 444 16 112 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 481 16 75 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single {
 		-webkit-border-image: url(../images/radiobutton.png) 518 16 38 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 555 16 1 16;
+		border-style: solid;
 	}
 }
 
@@ -106,75 +122,91 @@
 
 	.enyo-grouped-toolbutton.enyo-first {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 0 16 834 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 55 16 779 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 110 16 724 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 165 16 669 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 220 16 614 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 275 16 559 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 330 16 504 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 385 16 449 16;
+		border-style: solid;
 	}
 
 	/* dark */
 
 	.enyo-grouped-toolbutton-dark.enyo-first {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 440 16 394 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 495 16 339 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 550 16 284 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 605 16 229 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 660 16 174 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 715 16 119 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 770 16 64 16;
+		border-style: solid;
 	}
 
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-grouped-toolbutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 825 16 9 16;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/Header.css
+++ b/framework/source/palm/themes/Onyx/css/Header.css
@@ -3,6 +3,7 @@
 	-webkit-box-sizing: border-box;
 	min-height: 50px;
 	border-width: 2px 0;
+	border-style: solid;
 	background-color: #ccc;
 	color: #444;
 	/*
@@ -17,6 +18,7 @@
 .enyo-header.enyo-header-dark {
 	-webkit-border-image: url(../images/toolbar.png) 2 4 repeat stretch;
 	border-width: 2px 0;
+	border-style: solid;
 	background-color: #343434;
 	color: #fff;
 }
@@ -24,10 +26,12 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-header {
 		-webkit-border-image: url(../images-1.5/header.png) 3 0;
+		border-style: solid;
 	}
 	
 	.enyo-header.enyo-header-dark {
 		-webkit-border-image: url(../images/toolbar.png) 3 6 repeat stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/Input.css
+++ b/framework/source/palm/themes/Onyx/css/Input.css
@@ -8,11 +8,13 @@
 
 .enyo-input.enyo-input-focus {
 	-webkit-border-image: url(../images/input-focus.png) 14 14;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-input.enyo-input-focus {
 		-webkit-border-image: url(../images-1.5/input-focus.png) 21 21;
+		border-style: solid;
 	}
 }
 
@@ -62,12 +64,14 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-first.enyo-input.enyo-input-focus, .enyo-first > .enyo-input.enyo-input-focus {
 	padding-bottom: 12px;
 	border-width: 14px 14px 2px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/input-first-focus.png) 14 14 2 14;
 }
 
 .enyo-last.enyo-input.enyo-input-focus, .enyo-last > .enyo-input.enyo-input-focus {
 	padding-top: 12px;
 	border-width: 2px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/input-last-focus.png) 2 14 14 14;
 }
 
@@ -77,18 +81,22 @@ FIXME: we almost always want some padding on a enyo-item, except when it's surro
 .enyo-box-input.enyo-input.enyo-input-focus, .enyo-middle.enyo-input.enyo-input-focus, .enyo-middle > .enyo-input.enyo-input-focus {
 	background-color: transparent;
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/input-middle-focus.png) 14 14;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-first.enyo-input.enyo-input-focus, .enyo-first > .enyo-input.enyo-input-focus {
 		-webkit-border-image: url(../images-1.5/input-first-focus.png) 21 21 3 21;
+		border-style: solid;
 	}
 	.enyo-last.enyo-input.enyo-input-focus, .enyo-last > .enyo-input.enyo-input-focus {
 		-webkit-border-image: url(../images-1.5/input-last-focus.png) 3 21 21 21;
+		border-style: solid;
 	}
 	
 	.enyo-box-input.enyo-input.enyo-input-focus, .enyo-middle.enyo-input.enyo-input-focus, .enyo-middle > .enyo-input.enyo-input-focus {
 		-webkit-border-image: url(../images-1.5/input-middle-focus.png) 21 21;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/Menu.css
+++ b/framework/source/palm/themes/Onyx/css/Menu.css
@@ -1,6 +1,7 @@
 .enyo-popup.enyo-popup-menu {
 	min-width: inherit;
 	border-width: 20px;
+	border-style: solid;
 	-webkit-border-image: url(../images/menu-background.png) 20 20 20 20 stretch stretch;
 	
 	/* FIXME: consider when works more reliably */
@@ -60,6 +61,7 @@
 	}
 	.enyo-popup.enyo-popup-menu {
 		-webkit-border-image: url(../images-1.5/menu-background.png) 30 30 30 30 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/ModalDialog.css
+++ b/framework/source/palm/themes/Onyx/css/ModalDialog.css
@@ -1,6 +1,7 @@
 .enyo-modaldialog {
 	width: 320px;
 	border-width: 42px 24px 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/dialog.png) 42 24 24 24 stretch stretch;
 	-webkit-transition-property: opacity;
 	-webkit-transition-duration: 0.5s;
@@ -22,26 +23,31 @@
 .enyo-modaldialog-container .enyo-group,
 .enyo-modaldialog-container .group {
 	border-width: 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/dialog-group-unlabeled.png) 14 14 repeat repeat;
 	margin: 8px 0;
 }
 .enyo-modaldialog-container .enyo-group.labeled {
 	border-width: 36px 14px 14px 14px;
+	border-style: solid;
 	-webkit-border-image: url(../images/dialog-group-labeled.png) 36 14 14 14 repeat repeat;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-modaldialog {
 		-webkit-border-image: url(../images-1.5/dialog.png) 63 36 36 36 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-modaldialog-container .enyo-group,
 	.enyo-modaldialog-container .group {
 		-webkit-border-image: url(../images-1.5/dialog-group-unlabeled.png) 21 21 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-modaldialog-container .enyo-group.labeled {
 		-webkit-border-image: url(../images-1.5/dialog-group-labeled.png) 54 21 21 21 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/PickerButton.css
+++ b/framework/source/palm/themes/Onyx/css/PickerButton.css
@@ -1,6 +1,7 @@
 .enyo-picker-button {
 	-webkit-border-image: url(../images/picker-pill.png) 10;
 	border-width: 10px;
+	border-style: solid;
 	font-size: 16px;
 	line-height: 32px;
 }
@@ -13,26 +14,32 @@
 
 .enyo-picker-button.enyo-button {
 	-webkit-border-image: url(../images/picker-pill.png) 10;
+	border-style: solid;
 }
 
 .enyo-picker-button.enyo-button-down {
 	-webkit-border-image: url(../images/picker-pill-downstate.png) 10;
+	border-style: solid;
 }
 
 .enyo-picker-button.enyo-button-focus {
 	-webkit-border-image: url(../images/picker-pill-focus.png) 10;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-picker-button {
 		-webkit-border-image: url(../images-1.5/picker-pill.png) 15;
+		border-style: solid;
 	}
 
 	.enyo-picker-button.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/picker-pill-downstate.png) 15;
+		border-style: solid;
 	}
 
 	.enyo-picker-button.enyo-button-focus {
 		-webkit-border-image: url(../images-1.5/picker-pill-focus.png) 15;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/PickerGroup.css
+++ b/framework/source/palm/themes/Onyx/css/PickerGroup.css
@@ -4,6 +4,7 @@
 
 .enyo-pickergroup-pickerpopup {
 	border-width: 0;
+	border-style: solid;
 	-webkit-border-image: none;
 	min-width: 0px;
 }

--- a/framework/source/palm/themes/Onyx/css/Popup.css
+++ b/framework/source/palm/themes/Onyx/css/Popup.css
@@ -8,12 +8,14 @@
 	top: 0px;
 	-webkit-box-sizing: border-box;
 	border-width: 24px;
+	border-style: solid;
 	-webkit-border-image: url(../images/popup.png) 24 24 24 24 stretch stretch;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-popup {
 		-webkit-border-image: url(../images-1.5/popup.png) 36 36 36 36 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/ProgressBar.css
+++ b/framework/source/palm/themes/Onyx/css/ProgressBar.css
@@ -1,6 +1,7 @@
 .enyo-progress-bar {
 	height: 12px;
 	border-width: 0 4px;
+	border-style: solid;
 	-webkit-border-image: url(../images/progress-bar.png) 0 4 0 4 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -10,6 +11,7 @@
 	margin: 0 -5px;
 	height: 12px;
 	border-width: 0 4px;
+	border-style: solid;
 	position: absolute;
 	z-index:10; /* for progressSlider altBarPosition */
 	-webkit-border-image: url(../images/progress-bar-inner.png) 0 4 0 4 repeat repeat;
@@ -19,9 +21,11 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-bar {
 		-webkit-border-image: url(../images-1.5/progress-bar.png) 0 6 0 6 stretch stretch;
+		border-style: solid;
 	}
 	.enyo-progress-bar-inner {
 		-webkit-border-image: url(../images-1.5/progress-bar-inner.png) 0 6 0 6 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/ProgressBarItem.css
+++ b/framework/source/palm/themes/Onyx/css/ProgressBarItem.css
@@ -2,6 +2,7 @@
 .enyo-progress-bar-item {
 	min-height: 24px;
 	border-width: 12px 0px;
+	border-style: solid;
 	-webkit-border-image: url(../images/progress-item.png) 12 0 12 0 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -12,6 +13,7 @@
 	padding: 12px 0px;
 	height:100%;
 	border-width: 0 8px 0 0;
+	border-style: solid;
 	position:absolute;
 	-webkit-border-image: url(../images/progress-item-inner.png) 0 8 0 0 repeat stretch;
 }
@@ -24,8 +26,10 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-bar-item {
 		-webkit-border-image: url(../images-1.5/progress-item.png) 18 0 18 0 stretch repeat;
+		border-style: solid;
 	}
 	.enyo-progress-bar-item-inner {
 		-webkit-border-image: url(../images-1.5/progress-item-inner.png) 0 12 0 0 repeat stretch;
+		border-style: solid;
 	}	
 }

--- a/framework/source/palm/themes/Onyx/css/ProgressButton.css
+++ b/framework/source/palm/themes/Onyx/css/ProgressButton.css
@@ -2,6 +2,7 @@
 	min-height: 34px;
 	border-width: 4px;
 	border-radius: 5px;
+	border-style: solid;
 	-webkit-border-image: url(../images/button-down.png) 4 4 4 4 stretch stretch;
 	color: white;
 	background-color: rgba(23,23,23,0.5);
@@ -17,6 +18,7 @@
 	bottom: 0;
 	border-width: 4px;
 	border-radius: 5px;
+	border-style: solid;
 	position: absolute;
 	-webkit-border-image: url(../images/button.png) 4 4 4 4 stretch stretch;
 }
@@ -38,10 +40,12 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-button {
 		-webkit-border-image: url(../images-1.5/button-down.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-button-inner {
 		-webkit-border-image: url(../images-1.5/button.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-button-cancel {

--- a/framework/source/palm/themes/Onyx/css/ProgressSlider.css
+++ b/framework/source/palm/themes/Onyx/css/ProgressSlider.css
@@ -1,6 +1,7 @@
 .enyo-progress-slider {
 	height: 10px;
 	border-width: 0 4px;
+	border-style: solid;
 	-webkit-border-image: url(../images/slider-track.png) 0 4 0 4 repeat repeat;
 	-webkit-box-sizing: border-box;
 	position:relative;
@@ -9,6 +10,7 @@
 .enyo-progress-slider-alt-bar, .enyo-progress-slider > .enyo-progress-bar-inner {
 	height: 10px;
 	border-width: 0 4px;
+	border-style: solid;
 	margin: 0 -4px;
 	position: absolute;
 	-webkit-border-image: url(../images/slider-progress.png) 0 4 0 4 repeat repeat;
@@ -16,6 +18,7 @@
 
 .enyo-progress-slider-alt-bar {
 	z-index:5; /* under primary progress */
+	border-style: solid;
 	-webkit-border-image: url(../images/slider-progress-secondary.png) 0 4 0 4 repeat repeat;
 	-webkit-transition: width 0.3s ease;
 }
@@ -24,14 +27,17 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-progress-slider {
 		-webkit-border-image: url(../images-1.5/slider-track.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-slider > .enyo-progress-bar-inner {
 		-webkit-border-image: url(../images-1.5/slider-progress.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 	
 	.enyo-progress-slider-alt-bar {
 		-webkit-border-image: url(../images-1.5/slider-progress-secondary.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/RadioButton.css
+++ b/framework/source/palm/themes/Onyx/css/RadioButton.css
@@ -44,38 +44,46 @@
 @media (-webkit-max-device-pixel-ratio:1.49) { /* 1x */
 	.enyo-radiobutton.enyo-first {
 		-webkit-border-image: url(../images/radiobutton.png) 0 16 556 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 37 16 519 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle {
 		-webkit-border-image: url(../images/radiobutton.png) 74 16 482 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 111 16 445 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last {
 		-webkit-border-image: url(../images/radiobutton.png) 148 16 408 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 185 16 371 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single {
 		-webkit-border-image: url(../images/radiobutton.png) 222 16 334 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 259 16 297 16;
+		border-style: solid;
 	}
 
 
@@ -83,38 +91,46 @@
 
 	.enyo-radiobutton-dark.enyo-first {
 		-webkit-border-image: url(../images/radiobutton.png) 296 16 260 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 333 16 223 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle {
 		-webkit-border-image: url(../images/radiobutton.png) 370 16 186 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 407 16 149 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last {
 		-webkit-border-image: url(../images/radiobutton.png) 444 16 112 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 481 16 75 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single {
 		-webkit-border-image: url(../images/radiobutton.png) 518 16 38 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 555 16 1 16;
+		border-style: solid;
 	}
 
 
@@ -122,6 +138,7 @@
 
 	.enyo-tabbutton.enyo-first, .enyo-tabbutton.enyo-middle, .enyo-tabbutton.enyo-last, .enyo-tabbutton.enyo-single {
 		-webkit-border-image: url(../images/radiobutton.png) 74 16 482 16;
+		border-style: solid;
 	}
 
 	.enyo-tabbutton.enyo-first.enyo-button-depressed,
@@ -133,6 +150,7 @@
 	.enyo-tabbutton.enyo-single.enyo-button-depressed,
 	.enyo-tabbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images/radiobutton.png) 111 16 445 16;
+		border-style: solid;
 	}
 
 }
@@ -148,38 +166,46 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-radiobutton.enyo-first {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 0 16 834 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 55 16 779 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 110 16 724 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 165 16 669 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 220 16 614 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 275 16 559 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 330 16 504 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 385 16 449 16;
+		border-style: solid;
 	}
 
 
@@ -187,38 +213,46 @@
 
 	.enyo-radiobutton-dark.enyo-first {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 440 16 394 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-first.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-first.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 495 16 339 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 550 16 284 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-middle.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 605 16 229 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 660 16 174 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-last.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-last.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 715 16 119 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 770 16 64 16;
+		border-style: solid;
 	}
 
 	.enyo-radiobutton-dark.enyo-single.enyo-button-depressed,
 	.enyo-radiobutton-dark.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 825 16 9 16;
+		border-style: solid;
 	}
 
 
@@ -226,6 +260,7 @@
 
 	.enyo-tabbutton.enyo-first, .enyo-tabbutton.enyo-middle, .enyo-tabbutton.enyo-last, .enyo-tabbutton.enyo-single {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 110 16 724 16;
+		border-style: solid;
 	}
 
 	.enyo-tabbutton.enyo-first.enyo-button-depressed,
@@ -237,6 +272,7 @@
 	.enyo-tabbutton.enyo-single.enyo-button-depressed,
 	.enyo-tabbutton.enyo-single.enyo-button-down {
 		-webkit-border-image: url(../images-1.5/radiobutton.png) 165 16 669 16;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/RoundedInput.css
+++ b/framework/source/palm/themes/Onyx/css/RoundedInput.css
@@ -1,5 +1,6 @@
 .enyo-input.enyo-rounded-input, .enyo-input.enyo-rounded-input.enyo-input-focus {
 	border-width: 6px 20px;
+	border-style: solid;
 	-webkit-box-sizing: border-box;
 	-webkit-border-image: url(../images/roundedbox.png) 6 20;
 	margin: 2px 0;
@@ -14,5 +15,6 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-input.enyo-rounded-input, .enyo-input.enyo-rounded-input.enyo-input-focus {
 		-webkit-border-image: url(../images-1.5/roundedbox.png) 9 30;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/Slider.css
+++ b/framework/source/palm/themes/Onyx/css/Slider.css
@@ -23,6 +23,7 @@
 .enyo-slider-progress {
 	height: 10px;
 	border-width: 0px 4px;
+	border-style: solid;
 	-webkit-border-image: url(../images/slider-track.png) 0 4 0 4 repeat repeat;
 	margin: 20px 0px;
 	position:relative;
@@ -40,5 +41,6 @@
 	
 	.enyo-slider-progress {
 		-webkit-border-image: url(../images-1.5/slider-track.png) 0 6 0 6 repeat stretch;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/ToggleButton.css
+++ b/framework/source/palm/themes/Onyx/css/ToggleButton.css
@@ -18,39 +18,47 @@
 
 .enyo-toggle-button-bar.on {
 	border-width: 0px 30px 0px 8px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 1 30 97 8;
 }
 
 .enyo-toggle-button-bar.off {
 	border-width: 0px 8px 0px 30px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 33 8 65 30;
 }
 
 .enyo-toggle-button-bar.disabled.on {
 	border-width: 0px 30px 0px 8px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 65 30 33 8;
 }
 
 .enyo-toggle-button-bar.disabled.off {
 	border-width: 0px 8px 0px 30px;
+	border-style: solid;
 	-webkit-border-image: url(../images/toggle-button.png) 97 8 1 30;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-toggle-button-bar.on {
 		-webkit-border-image: url(../images-1.5/toggle-button.png) 2 45 145 12 stretch stretch;
+		border-style: solid;
 	}
 
 	.enyo-toggle-button-bar.off {
 		-webkit-border-image: url(../images-1.5/toggle-button.png) 50 12 97 45 stretch stretch;
+		border-style: solid;
 	}
 
 	.enyo-toggle-button-bar.disabled.on {
 		-webkit-border-image: url(../images-1.5/toggle-button.png) 98 45 49 12 stretch stretch;
+		border-style: solid;
 	}
 
 	.enyo-toggle-button-bar.disabled.off {
 		-webkit-border-image: url(../images-1.5/toggle-button.png) 146 12 1 45 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/ToolButton.css
+++ b/framework/source/palm/themes/Onyx/css/ToolButton.css
@@ -31,6 +31,7 @@
 
 .enyo-tool-button-client.enyo-tool-button-captioned.enyo-button-down, .enyo-tool-button-client.enyo-button-depressed {
 	-webkit-border-image: url(../images/button-down.png) 4 4 4 4 stretch stretch;
+	border-style: solid;
 }
 
 .enyo-tool-button-client.enyo-button-depressed {
@@ -46,10 +47,12 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-tool-button-client.enyo-tool-button-captioned.enyo-button-down, .enyo-tool-button-client.enyo-button-depressed {
 		-webkit-border-image: url(../images-1.5/button-down.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 	
 	.enyo-tool-button-client.enyo-tool-button-captioned {
 		-webkit-border-image: url(../images-1.5/button-toolbar.png) 6 6 6 6 stretch stretch;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/ToolInput.css
+++ b/framework/source/palm/themes/Onyx/css/ToolInput.css
@@ -10,14 +10,17 @@
 
 .enyo-input.enyo-tool-input.enyo-input-focus {
 	-webkit-border-image: url(../images/input-tool-focus.png) 6 6 6 6;
+	border-style: solid;
 }
 
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-input.enyo-tool-input {
 		-webkit-border-image: url(../images-1.5/input-tool.png) 9 9 9 9;
+		border-style: solid;
 	}
 	.enyo-input.enyo-tool-input.enyo-input-focus {
 		-webkit-border-image: url(../images-1.5/input-tool-focus.png) 9 9 9 9;
+		border-style: solid;
 	}
 }
 

--- a/framework/source/palm/themes/Onyx/css/Toolbar.css
+++ b/framework/source/palm/themes/Onyx/css/Toolbar.css
@@ -4,12 +4,14 @@
 	min-height: 54px;
 	-webkit-box-sizing: border-box;
 	-webkit-border-image: url(../images/toolbar.png) 2 4 repeat stretch;
+	border-style: solid;
 	border-width: 2px 4px;
 	background-color: #343434;
 }
 
 .enyo-toolbar-light {
 	-webkit-border-image: url(../images/toolbar-light.png) 2 4 repeat stretch;
+	border-style: solid;
 	background-color: #a9a9a9;
 }
 
@@ -25,9 +27,11 @@
 @media (-webkit-min-device-pixel-ratio:1.5) {
 	.enyo-toolbar {
 		-webkit-border-image: url(../images-1.5/toolbar.png) 3 6 repeat stretch;
+		border-style: solid;
 	}
 	
 	.enyo-toolbar-light {
 		-webkit-border-image: url(../images-1.5/toolbar-light.png) 3 6 repeat stretch;
+		border-style: solid;
 	}
 }

--- a/framework/source/palm/themes/Onyx/css/WebView.css
+++ b/framework/source/palm/themes/Onyx/css/WebView.css
@@ -9,4 +9,5 @@
 .enyo-webview-popup-spinner {
 	min-width: 0px;
 	-webkit-border-image: none;
+	border-style: solid;
 }

--- a/support/examples/Theming/2-theme/index.html
+++ b/support/examples/Theming/2-theme/index.html
@@ -12,10 +12,12 @@
 		}
 		#app-button1.enyo-button {
 			-webkit-border-image: url(images/aristo-default-68x31.png) 5 5 5 5 stretch stretch;
+			border-style: solid;
 		}
 		#app-button1.enyo-button-down {
 			padding: 4px 8px 2px;
 			-webkit-border-image: url(images/aristo-down-68x31.png) 5 5 5 5 stretch stretch;
+			border-style: solid;
 		}
 	</style>
 	<style type="text/css">
@@ -26,10 +28,12 @@
 		}
 		.my-button.enyo-button {
 			-webkit-border-image: url(images/aristo-normal-68x31.png) 5 5 5 5 stretch stretch;
+			border-style: solid;
 		}
 		.my-button.enyo-button-down {
 			padding: 4px 8px 2px;
 			-webkit-border-image: url(images/aristo-hot-68x31.png) 5 5 5 5 stretch stretch;
+			border-style: solid;
 		}
 	</style>
 </head>


### PR DESCRIPTION
As per
https://www.w3.org/TR/2005/WD-css3-background-20050216/#the-border-image
and
https://groups.google.com/a/chromium.org/forum/#!searchin/blink-dev/border-image/blink-dev/J7rvFkcn8TU/OtIcXTDDAQAJ
we need now to explicitly use 'border-style: solid' in combination with
-webkit-border-image for it to work correctly.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>