### PR TITLE
contactsui: Don't decorate requests with $activity

### DIFF
--- a/framework/lib/contactsui/mojoshim/mojoCore-service.js
+++ b/framework/lib/contactsui/mojoshim/mojoCore-service.js
@@ -36,9 +36,15 @@ function assignPrototype(fn, proto) {
 				console.warn("No activity id available for service request!");
 			}
 			else {
-				parameters.$activity = {
+				if (true) {
+					console.log("mojoCore-service: skipping problematic activity id decoration!");
+				}
+				else {
+					// dead code
+					parameters.$activity = {
 					activityId: PalmSystem.activityId
-				};
+					};
+				}
 			}
 		}
 		


### PR DESCRIPTION
This leads to non-standard LS2 calls, which conflicts with schema checks.
Fixes messages like the following for each contact in emails:

2019-06-29T05:33:02.884186Z [261] user.debug mojodb-luna [] DB8 DBGMSG {} [db_lunaService] response sent: {"returnValue":true,"responses":[{"returnValue":true,"results":[]},{"returnValue":true,"results":[]}]}
2019-06-29T05:33:02.884576Z [261] user.debug mojodb-luna [] DB8 DBGMSG {} [db_lunaService] request received: {"query":{"from":"com.palm.person:1","where":[{"prop":"emails.normalizedValue","op":"=","val":"notifications@github.com"}]},"$activity":{"activityId":41}}
2019-06-29T05:33:02.884606Z [261] user.warning mojodb-luna [] DB8 MOJ_SERVICE_WARNING {"sender":"com.palm.app.email","method":"find","payload":{"$activity":{"activityId":41},"query":{"from":"com.palm.person:1","where":[{"op":"=","prop":"emails.normalizedValue","val":"notifications@github.com"}]}},"error":"invalid parameters: caller='com.palm.app.email' error='property not allowed - '$activity''","reqErr":22}

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>