### PR TITLE
webosgestures: let Enyo use preventDefault()

### DIFF
--- a/framework/build/enyo-build.js
+++ b/framework/build/enyo-build.js
@@ -2720,7 +2720,7 @@ target: enyo.webosGesture.lastDownTarget
 }, b);
 enyo.dispatch(c);
 }, Mojo.screenOrientationChanged = function() {}, enyo.requiresWindow(function() {
-document.addEventListener("touchstart", enyo.dispatch), document.addEventListener("touchmove", enyo.dispatch), document.addEventListener("touchend", enyo.dispatch);
+document.addEventListener("touchstart", enyo.dispatch, {passive:false}), document.addEventListener("touchmove", enyo.dispatch, {passive:false}), document.addEventListener("touchend", enyo.dispatch, {passive:false});
 })), typeof webosEvent == "undefined" && (webosEvent = {
 event: enyo.nop,
 start: enyo.nop,

--- a/framework/source/compatibility/webosGesture.js
+++ b/framework/source/compatibility/webosGesture.js
@@ -32,9 +32,10 @@ if (window.PalmSystem) {
 
 	enyo.requiresWindow(function() {
 		// add gesture event suppport
-		document.addEventListener("touchstart", enyo.dispatch);
-		document.addEventListener("touchmove", enyo.dispatch);
-		document.addEventListener("touchend", enyo.dispatch);
+		// force passive to "false" to let Enyo use preventDefault()
+		document.addEventListener("touchstart", enyo.dispatch, {passive:false});
+		document.addEventListener("touchmove", enyo.dispatch, {passive:false});
+		document.addEventListener("touchend", enyo.dispatch, {passive:false});
 	});
 }
 


### PR DESCRIPTION
This fixes the double click issue with the mail account separator expander