### PR TITLE
enyo-1.0: Use localStorage where possible

### DIFF
--- a/framework/build/enyo-build.js
+++ b/framework/build/enyo-build.js
@@ -1493,9 +1493,16 @@ type: "text/javascript",
 src: a
 }));
 }, enyo.getCookie = function(a) {
+if(typeof localStorage != "undefined") {
+return localStorage.getItem(a);   
+} else {
 var b = document.cookie.match(new RegExp("(?:^|; )" + a + "=([^;]*)"));
 return b ? decodeURIComponent(b[1]) : undefined;
+}
 }, enyo.setCookie = function(a, b, c) {
+if(typeof localStorage != "undefined") {
+        localStorage.setItem(a, b);
+} else {
 var d = a + "=" + encodeURIComponent(b), e = c || {}, f = e.expires;
 if (typeof f == "number") {
 var g = new Date;
@@ -1505,6 +1512,7 @@ f && f.toUTCString && (e.expires = f.toUTCString());
 var h, i;
 for (h in e) d += "; " + h, i = e[h], i !== !0 && (d += "=" + i);
 document.cookie = d;
+}
 }, enyo.dom = {
 getComputedStyle: function(a) {
 return window.getComputedStyle(a, null);

--- a/framework/source/dom/dom.js
+++ b/framework/source/dom/dom.js
@@ -62,8 +62,12 @@ enyo.loadScript = function(inUrl) {
 	Gets a named value from the document cookie.
 */
 enyo.getCookie = function(inName) {
-	var matches = document.cookie.match(new RegExp("(?:^|; )" + inName + "=([^;]*)"));
-	return matches ? decodeURIComponent(matches[1]) : undefined;
+	if(typeof localStorage != "undefined") {
+		localStorage.getItem(inName);
+	} else {
+		var matches = document.cookie.match(new RegExp("(?:^|; )" + inName + "=([^;]*)"));
+		return matches ? decodeURIComponent(matches[1]) : undefined;
+	}
 };
 
 /**
@@ -79,31 +83,35 @@ enyo.getCookie = function(inName) {
 	start chrome with the <code>--enable-file-cookies</code> switch to allow cookies to be set.
 */
 enyo.setCookie = function(inName, inValue, inProps) {
-	var cookie = inName + "=" + encodeURIComponent(inValue);
-	var p = inProps || {};
-	//
-	// FIXME: expires=0 seems to disappear right away, not on close? (FF3)  Change docs?
-	var exp = p.expires;
-	if (typeof exp == "number") {
-		var d = new Date();
-		d.setTime(d.getTime() + exp*24*60*60*1000);
-		exp = d;
-	}
-	if (exp && exp.toUTCString) {
-		p.expires = exp.toUTCString();
-	}
-	//
-	var name, value;
-	for (name in p){
-		cookie += "; " + name;
-		value = p[name];
-		if (value !== true) {
-			cookie += "=" + value;
+	if(typeof localStorage != "undefined") {
+		localStorage.setItem(inName, inValue);
+	} else {
+		var cookie = inName + "=" + encodeURIComponent(inValue);
+		var p = inProps || {};
+		//
+		// FIXME: expires=0 seems to disappear right away, not on close? (FF3)  Change docs?
+		var exp = p.expires;
+		if (typeof exp == "number") {
+			var d = new Date();
+			d.setTime(d.getTime() + exp*24*60*60*1000);
+			exp = d;
 		}
+		if (exp && exp.toUTCString) {
+			p.expires = exp.toUTCString();
+		}
+		//
+		var name, value;
+		for (name in p){
+			cookie += "; " + name;
+			value = p[name];
+			if (value !== true) {
+				cookie += "=" + value;
+			}
+		}
+		//
+		//console.log(cookie);
+		document.cookie = cookie;
 	}
-	//
-	//console.log(cookie);
-	document.cookie = cookie;
 };
 
 //* @public


### PR DESCRIPTION
To work around issues with cookies in Chrome 80+ which restricted and afterwards removed file cookies completely, because they were not compliant with specs and shouldn't have worked ever anyway. See https://bugs.chromium.org/p/chromium/issues/detail?id=470482 and https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure for example.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>