### PR TITLE
fix for chromium touch intervention causing double taps

### DIFF
--- a/framework/build/enyo-build.js
+++ b/framework/build/enyo-build.js
@@ -2708,7 +2708,10 @@ touchend: function(a) {
 this._send("mouseup", a.changedTouches[0]), this._send("click", a.changedTouches[0]);
 },
 connect: function() {
-document.ontouchstart = enyo.dispatch, document.ontouchmove = enyo.dispatch, document.ontouchend = enyo.dispatch;
+//Disable Chromium intervention on older framework (see: https://developer.chrome.com/blog/scrolling-intervention/)
+document.addEventListener(ontouchstart, enyo.dispatch, {passive:false});
+document.addEventListener(ontouchmove, enyo.dispatch, {passive:false});
+document.addEventListener(ontouchend, enyo.dispatch, {passive:false});
 }
 }, enyo.iphoneGesture.connect());
 });

--- a/framework/build/enyo-build.js
+++ b/framework/build/enyo-build.js
@@ -2727,6 +2727,7 @@ touchend: function(a) {
 this._send("mouseup", a.changedTouches[0]), this._send("click", a.changedTouches[0]);
 },
 connect: function() {
+var options;
 if (enyo.passiveSupported()) options = {passive:false};
 document.addEventListener("touchstart", enyo.dispatch, options);
 document.addEventListener("touchmove", enyo.dispatch, options);
@@ -2750,7 +2751,8 @@ target: enyo.webosGesture.lastDownTarget
 }, b);
 enyo.dispatch(c);
 }, Mojo.screenOrientationChanged = function() {}, enyo.requiresWindow(function() {
-if (enyo.passiveSupported()) options = {passive:false};
+var options;
+if (enyo.passiveSupported()) var options = {passive:false}
 document.addEventListener("touchstart", enyo.dispatch, options), document.addEventListener("touchmove", enyo.dispatch, options), document.addEventListener("touchend", enyo.dispatch, options);
 })), typeof webosEvent == "undefined" && (webosEvent = {
 event: enyo.nop,

--- a/framework/build/enyo-build.js
+++ b/framework/build/enyo-build.js
@@ -1881,7 +1881,22 @@ return this._animation && this._animation.animating;
 });
 
 // dom/Dispatcher.js
-
+enyo.passiveSupported = function() {
+ passiveSupported = false;
+ try {
+  var options = {
+  get passive() {
+   passiveSupported = true;
+   return false;
+  },
+ };
+ window.addEventListener("test", null, options);
+ window.removeEventListener("test", null, options);
+ } catch (err) {
+  passiveSupported = false;
+ }
+ return passiveSupported;
+};
 enyo.$ = {}, enyo.dispatcher = {
 handlerName: "dispatchDomEvent",
 captureHandlerName: "captureDomEvent",
@@ -1893,7 +1908,11 @@ events: [ "mousedown", "mouseup", "mouseover", "mouseout", "mousemove", "mousewh
 windowEvents: [ "resize", "load", "unload" ],
 connect: function() {
 var a = enyo.dispatcher;
-for (var b = 0, c; c = a.events[b]; b++) document.addEventListener(c, enyo.dispatch, !1);
+for (var b = 0, c; c = a.events[b]; b++) {
+ var options = !1;
+ if (enyo.passiveSupported()) options = { passive:false }
+   document.addEventListener(c, enyo.dispatch, options);
+}
 for (b = 0, c; c = a.windowEvents[b]; b++) window.addEventListener(c, enyo.dispatch, !1);
 },
 findDispatchTarget: function(a) {
@@ -2708,10 +2727,10 @@ touchend: function(a) {
 this._send("mouseup", a.changedTouches[0]), this._send("click", a.changedTouches[0]);
 },
 connect: function() {
-//Disable Chromium intervention on older framework (see: https://developer.chrome.com/blog/scrolling-intervention/)
-document.addEventListener(ontouchstart, enyo.dispatch, {passive:false});
-document.addEventListener(ontouchmove, enyo.dispatch, {passive:false});
-document.addEventListener(ontouchend, enyo.dispatch, {passive:false});
+if (enyo.passiveSupported()) options = {passive:false};
+document.addEventListener("touchstart", enyo.dispatch, options);
+document.addEventListener("touchmove", enyo.dispatch, options);
+document.addEventListener("touchend", enyo.dispatch, options);
 }
 }, enyo.iphoneGesture.connect());
 });
@@ -2731,7 +2750,8 @@ target: enyo.webosGesture.lastDownTarget
 }, b);
 enyo.dispatch(c);
 }, Mojo.screenOrientationChanged = function() {}, enyo.requiresWindow(function() {
-document.addEventListener("touchstart", enyo.dispatch, {passive:false}), document.addEventListener("touchmove", enyo.dispatch, {passive:false}), document.addEventListener("touchend", enyo.dispatch, {passive:false});
+if (enyo.passiveSupported()) options = {passive:false};
+document.addEventListener("touchstart", enyo.dispatch, options), document.addEventListener("touchmove", enyo.dispatch, options), document.addEventListener("touchend", enyo.dispatch, options);
 })), typeof webosEvent == "undefined" && (webosEvent = {
 event: enyo.nop,
 start: enyo.nop,


### PR DESCRIPTION
Combined with Tofe's previous pull, this change stopped two touch events from firing for each single tap in enyo1.0 apps on modern Chromium, without preventing scrolling.