### PR TITLE
windows: prefer the URL's enyoWindowParams over PalmSystem.launchParams

### DIFF
--- a/framework/source/palm/system/windows/manager.js
+++ b/framework/source/palm/system/windows/manager.js
@@ -174,9 +174,30 @@ enyo.windows.manager = {
 // Setup windows api during enyo boot process:
 enyo.requiresWindow(function() {
 	// Assign windowParams.
-	var params = enyo.windowParams || (window.PalmSystem && PalmSystem.launchParams);
+	//
+	// Order matters here. ?enyoWindowParams= is written by openWindow() above and is
+	// therefore per-window data unambiguously meant for this window. It has to be
+	// consulted BEFORE PalmSystem.launchParams, which is per-app-instance data.
+	//
+	// On legacy webOS the two amounted to the same thing: LunaSysMgr put the window's
+	// own parameters in launchParams, so reading it first was correct and the URL was
+	// only a backstop. Under WAM they are different objects. WAM hands every page,
+	// including a cross-app child opened with window.open(), a launchParams of the form
+	//
+	//     {"displayAffinity":0,"instanceId":"..."}
+	//
+	// which is non-empty and therefore truthy. Reading it first satisfied the old
+	// "!params" guard, so the URL was never consulted and every cross-app window came
+	// up with windowParams = {displayAffinity, instanceId} rather than what its opener
+	// passed. Account validators then saw no template, fell back to a bare
+	// {templateId:...} stub, and the Accounts app showed an empty capability list and
+	// threw in modify.js on "Create Account".
+	var params = enyo.windowParams;
 	if(!params && enyo.args.enyoWindowParams) {
 		params = decodeURIComponent(enyo.args.enyoWindowParams);
+	}
+	if(!params && window.PalmSystem) {
+		params = PalmSystem.launchParams;
 	}
 	enyo.windows.finishOpenWindow(window, params);
 	//


### PR DESCRIPTION
Cross-app windows opened via enyo.windows.openWindow() came up with the wrong windowParams under WAM. The bootstrap read:

    var params = enyo.windowParams || (window.PalmSystem && PalmSystem.launchParams);
    if(!params && enyo.args.enyoWindowParams) { ... }

so the URL was only consulted when launchParams was falsy.

On legacy webOS that was fine, because LunaSysMgr put the window's own parameters in launchParams and the URL was just a backstop. WAM does not: it hands every page, including a cross-app child opened with window.open(), an app-instance launchParams of the form

    {"displayAffinity":0,"instanceId":"..."}

which is non-empty and therefore truthy, so the "!params" guard was never satisfied and the URL was never read. Instrumenting a validator page showed it exactly:

    hasPalmSystem=yes lpType=string lpTruthy=yes lpLen=87
    searchLen=3089 argsPresent=yes argsLen=3071
    wp=displayAffinity,instanceId hasTemplate=no capCount=-1

The parameters were present in the URL and enyo had already parsed them into enyo.args, but windowParams came out as WAM's {displayAffinity, instanceId}.

Downstream that surfaced as broken account creation: an account validator found no template in its params, fell back to a bare {templateId:...} stub, and echoed the stub back to the Accounts app, which trusts the returned template (entry-add.js passes msg.template to displayCreateView). modify.js then showed an empty "Use account with" list, because displayCapabilities() guards on capabilityProviders, and threw at line 213 on "Create Account", because createAccountTapped() does not.

Fixed by ordering the sources by specificity: ?enyoWindowParams= is written by openWindow() itself and is unambiguously meant for this window, so it wins; launchParams stays as the last resort, so consumers reading displayAffinity or instanceId out of it are unaffected.

This should also make the hand-rolled getQueryVariable() fallback in org.webosports.app.imvalidator's Validator.js redundant.